### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   # ── React Native: Jest unit + algorithm tests ────────────────────────────────
   react-native:


### PR DESCRIPTION
Potential fix for [https://github.com/Surrog/ArcheryCounter/security/code-scanning/9](https://github.com/Surrog/ArcheryCounter/security/code-scanning/9)

In general, the fix is to explicitly add a `permissions` block to the workflow (either at the root, applying to all jobs, or per-job) that grants only the minimal required scopes. Since this workflow only checks out and builds code and does not interact with issues, pull requests, or other write operations, `contents: read` is sufficient as a minimal starting point.

The best fix without changing existing functionality is to add a workflow-level `permissions` block right after the `name: CI` (or after the `on:` block) so it applies to all jobs that do not override permissions. We will set `contents: read`, which is the recommended minimal scope for typical CI jobs that just need to clone the repository. No other scopes appear necessary from the provided snippet. Concretely, in `.github/workflows/ci.yml`, we will insert:

```yaml
permissions:
  contents: read
```

between the existing `on:` block and the `jobs:` block (e.g., after line 5 or line 6 in the snippet). No imports or additional methods are needed, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
